### PR TITLE
Fix error when making default image

### DIFF
--- a/upldgallery.php
+++ b/upldgallery.php
@@ -101,6 +101,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'delete' && isset($_GET['img'])
 if (isset($_GET['action']) && $_GET['action'] == 'makedefault')
 {
 	$cropdefault = true;
+	$image = $_GET['img'];
 	$_SESSION['SELL_pict_url_temp'] = $_SESSION['SELL_pict_url'] = $_GET['img'];
 }
 


### PR DESCRIPTION
Without the $image variable you will get a warning similar to the following. This image name is passed by the make default checkbox but was not caught in the code.

Warning: getimagesize(E:/xampp/htdocs/auction_dev/uploaded/55t54tre3kriv568jtq7b96635/): failed to open stream: No such file or directory in E:\xampp\htdocs\auction_dev\upldgallery.php on line 201

Warning: Division by zero in E:\xampp\htdocs\auction_dev\upldgallery.php on line 204
