### PR TITLE
Fix escaping of SQL

### DIFF
--- a/email_request.php
+++ b/email_request.php
@@ -72,7 +72,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'proceed')
 			// send a copy to their mesasge box
 			$nowmessage = nl2br($system->cleanvars($message));
 			$query = "INSERT INTO " . $DBPrefix . "messages (sentto, sentfrom, sentat, message, subject)
-					VALUES (" . $user_id . ", " . $user->user_data['id'] . ", '" . time() . "', '" . $nowmessage . "', '" . $system->cleanvars(sprintf($MSG['651'], $item_title)) . "')";
+					VALUES (" . $user_id . ", " . $user->user_data['id'] . ", '" . time() . "', '" . mysql_real_escape_string($nowmessage) . "', '" . $system->cleanvars(sprintf($MSG['651'], $item_title)) . "')";
 			$system->check_mysql(mysql_query($query), $query, __LINE__, __FILE__);
 			$sent = true;
 		}


### PR DESCRIPTION
On my system I saw errors from malformed SQL queries due to astrophes used in messages sent by users through this email_request.php page. Perhaps mysql_real_escape_string should be added to the cleanvars functions.
