### PR TITLE
function invalidinvoice

### DIFF
--- a/order_packingslip.php
+++ b/order_packingslip.php
@@ -33,7 +33,7 @@ $system->check_mysql($res, $query, __LINE__, __FILE__);
 // check its real
 if (mysql_num_rows($res) < 1)
 {
-	invaildinvoice(true);
+	invalidinvoice(true);
 }
 
 $data = mysql_fetch_assoc($res);


### PR DESCRIPTION
It was misspelled and not matching up with the correctly spelled defined one in the common.php file.
