### PR TITLE
Update rss.php

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -132,7 +132,7 @@ while ($auction_data = mysql_fetch_assoc($res))
 	}
 
 	$template->assign_block_vars('rss', array(
-			'PRICE' => str_replace(array('<b>', '</b>'), '', $system->print_money(($auction_data['num_bids'] == 0) ? $auction_data['minimum_bid'] : $auction_data['current_bid'])),
+			'PRICE' => str_replace(array('<b>', '</b>'), '', $system->print_money(($auction_data['num_bids'] == 0) ? $auction_data['minimum_bid'] : $auction_data['current_bid'], true, false, false)),
 			'TITLE' => $system->uncleanvars($auction_data['title']),
 			'URL' => $system->SETTINGS['siteurl'] . 'item.php?id=' . $auction_data['id'],
 			'DESC' => $auction_data['description'],


### PR DESCRIPTION
The RSS feeds in both 1.0.6 and 1.1.0 include the price in the title, but when the price is obtained in rss.php, the print_money function isn't set correctly; it adds a hyperlink to the currency converter to the price, and since the title is in CDATA tags, it's output as plain text. To fix it, you simply need to add the “false” for the link parameter to the function call in rss.php.
