### PR TITLE
Update sell.tpl

### DIFF
--- a/themes/default/sell.tpl
+++ b/themes/default/sell.tpl
@@ -103,16 +103,16 @@ $(document).ready(function(){
 		$("#to_pay").text(current_fee);
 	});
 	$("#bn").blur(function(){
-		bn();
+		bin();
 	});
 	$("#bn_yes").click(function(){
-		bn();
+		bin();
 	});
 	$("#bn_no").click(function(){
 		$("#bn").val(0);
-		bn();
+		bin();
 	});
-	function bn(){
+	function bin(){
 		if (bn != parseInt($("#bn").val())){
 			if (parseInt($("#bn").val()) > 0)
 				updatefee(buyout_fee);


### PR DESCRIPTION
This fixes the "bn() is not a function" javascript error on sell.php. Javascript is confused because the name/ID of the bn element is the same as the function bn(). Changing the name of the function and the three places it's called prevents the error.
