### PR TITLE
Update rss.php

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -147,8 +147,12 @@ $template->assign_vars(array(
 		'XML' => '<?xml version="1.0" encoding="' . $CHARSET . '"?>', //as the template parser doesnt like <? tags
 		'PAGE_TITLE' => $system->SETTINGS['sitename'],
 		'SITEURL' => $system->SETTINGS['siteurl'],
+		'DESCRIPTIONTAG' => $system->SETTINGS['descriptiontag'],
+		'FEED' => $feed, 
 		'RSSTITLE' => $RSStitle
 		));
+		
+header('Content-Type: application/rss+xml;charset= ' . $CHARSET);
 
 $template->set_filenames(array(
 		'body' => 'rss.tpl'


### PR DESCRIPTION
These modifications fix a number of issues with the RSS feeds for WeBid. 

The default rss.php and rss.tpl use the site name for the feed title and description. This uses the meta description for the description instead of repeating the title.

You also add the Content Type via a header() call so that the RSS feeds validate.
