### PR TITLE
Fix XSS flaw in friend.php

### DIFF
--- a/friend.php
+++ b/friend.php
@@ -111,11 +111,11 @@ $template->assign_vars(array(
 		'CAPTCHATYPE' => $system->SETTINGS['spam_register'],
 		'CAPCHA' => (isset($capcha_text)) ? $capcha_text : '',
 		'TITLE' => $TPL_item_title,
-		'FRIEND_NAME' => (isset($_POST['friend_name'])) ? $_POST['friend_name'] : '',
-		'FRIEND_EMAIL' => (isset($_POST['friend_email'])) ? $_POST['friend_email'] : '',
-		'YOUR_NAME' => ($user->logged_in) ? $user->user_data['name'] : '',
-		'YOUR_EMAIL' => ($user->logged_in) ? $user->user_data['email'] : '',
-		'COMMENT' => (isset($_POST['sender_comment'])) ? $_POST['sender_comment'] : '',
+		'FRIEND_NAME' => (isset($_POST['friend_name'])) ? $system->cleanvars($_POST['friend_name']) : '',
+		'FRIEND_EMAIL' => (isset($_POST['friend_email'])) ?  $system->cleanvars($_POST['friend_email']) : '',
+		'YOUR_NAME' => ($user->logged_in) ? $system->cleanvars($user->user_data['name']) : '',
+		'YOUR_EMAIL' => ($user->logged_in) ? $system->cleanvars($user->user_data['email']) : '',
+		'COMMENT' => (isset($_POST['sender_comment'])) ? $system->cleanvars($_POST['sender_comment']) : '',
 		'EMAILSENT' => $emailsent
 		));
 


### PR DESCRIPTION
To test this flaw enter the following for the friend's email. Then when it returns the error on the email address move the mouse over the email address field to activate.

sample%40email.tst" onmouseover=prompt(971889) bad="
