### PR TITLE
Cosmetic alterations for featured items

### DIFF
--- a/index.php
+++ b/index.php
@@ -90,6 +90,8 @@ $query = "SELECT id, title, current_bid, pict_url, ends, num_bids, minimum_bid, 
         ORDER BY RAND() DESC LIMIT 12";
 $res = mysql_query($query);
 $system->check_mysql($res, $query, __LINE__, __FILE__);
+
+$i = 0;
 while($row = mysql_fetch_assoc($res))
 {
 	$ends = $row['ends'];
@@ -111,7 +113,10 @@ while($row = mysql_fetch_assoc($res))
 			'IMAGE' => (!empty($row['pict_url'])) ? 'getthumb.php?w=' . $system->SETTINGS['thumb_show'] . '&fromfile=' . $uploaded_path . $row['id'] . '/' . $row['pict_url'] : 'images/email_alerts/default_item_img.jpg',
 			'TITLE' => $row['title']
 			));
+ 	$i++;
 }
+
+$featured_items = ($i > 0) ? true : false;
 
 // get last created auctions
 $query = "SELECT id, title, starts from " . $DBPrefix . "auctions
@@ -234,7 +239,7 @@ if ($system->SETTINGS['newsbox'] == 1)
 
 $template->assign_vars(array(
 		'FLAGS' => ShowFlags(),
-
+		'B_FEATURED_ITEMS' => $featured_items,
 		'B_AUC_LAST' => $auc_last,
 		'B_HOT_ITEMS' => $hot_items,
 		'B_AUC_ENDSOON' => $end_soon,

--- a/language/EN/messages.inc.php
+++ b/language/EN/messages.inc.php
@@ -1695,4 +1695,7 @@ $MSG['350_1008'] = "Additional Shipping";
 $MSG['350_1009'] = "Additional Shipping Cost";
 $MSG['RPT_22'] = 'User ID'; 
 $MSG['RPT_23'] = '(leave blank for all)';
+
+$MSG['NAY_01'] = 'Featured Items';
+$MSG['NAY_02'] = 'All Items';
 ?>

--- a/themes/default/browse.tpl
+++ b/themes/default/browse.tpl
@@ -1,6 +1,10 @@
+<br>
 <!-- IF B_FEATURED_ITEMS -->
 	<table width="99%" border="0" cellspacing="1" cellpadding="4">
     <!-- BEGIN featured_items -->
+		<tr>
+			<td class="titTable4" colspan="4">{L_NAY_01}</td>
+		</tr>
 		<tr align="center">
 			<td align="center" width="15%">
 				<a href="{SITEURL}item.php?id={featured_items.ID}"><img src="{featured_items.IMAGE}" border="0"></a>
@@ -29,6 +33,9 @@
 
 	<table width="99%" border="0" cellspacing="1" cellpadding="4">
 <!-- BEGIN items -->
+		<tr>
+			<td class="titTable4" colspan="4">{L_NAY_02}</td>
+		</tr>
 		<tr align="center" {items.ROWCOLOUR}>
 			<td align="center" width="15%">
 				<a href="{SITEURL}item.php?id={items.ID}"><img src="{items.IMAGE}" border="0"></a>

--- a/themes/default/home.tpl
+++ b/themes/default/home.tpl
@@ -19,6 +19,10 @@
 </td>
 <td valign="top">
     <table width="100%" border="0" cellspacing="0" cellpadding="0" class="maincolum">
+    <!-- IF B_FEATURED_ITEMS -->
+    <tr>
+        <td class="titTable4">{L_NAY_01}</td>
+    </tr>
     <tr>
         <td class="table2">
         <!-- BEGIN featured -->
@@ -28,7 +32,8 @@
             </div>
         <!-- END featured -->
         </td>
-    </tr>  
+    </tr>
+    <!-- ENDIF -->  
     <!-- IF B_HOT_ITEMS -->
     <tr>
         <td class="titTable4">{L_279}</td>


### PR DESCRIPTION
To save confusion I have added headers to the featured items on the
homepage as well as the browse page, I have also added a new header ALL ITEMS
on the browse page.

index.php has had code added to only display the featured part if
featured items exist so the header is not always present.

There are many posts on the forum where people and their users are confused by items showing twice, something I fixed in my SP1 release but that got pulled out again.

Fully tested on a 1.1.1 clean install and working as of this commit.

Not sure where Git is picking up the extra ending TR from in home.tpl but it's not in my commit file
