### PR TITLE
Fixes missing zip code for packing slip/invoices

### DIFF
--- a/includes/functions_invoices.php
+++ b/includes/functions_invoices.php
@@ -45,7 +45,7 @@ function getAddressWinner($user_id)
 		'address'   => $result['address'],
 		'city'      => $result['city'],
 		'prov'      => $result['prov'],
-		'postcode'  => $result['zip'],
+		'zip'  	    => $result['zip'],
 		'country'   => $result['country'],
 		//'email'     => $result['email'],
 	);


### PR DESCRIPTION
There was no zip code showing on the invoices and packing slips. This fixes it.