### PR TITLE
fix for register.php for timezone

### DIFF
--- a/register.php
+++ b/register.php
@@ -453,7 +453,14 @@ for ($i = 1; $i <= 31; $i++)
 }
 $dobday .= '</select>';
 
-$selectsetting = (isset($_POST['TPL_timezone'])) ? $_POST['TPL_timezone'] : '';
+if (isset($_POST['TPL_timezone'])) {
+        $selectsetting = (isset($_POST['TPL_timezone'])) ? $_POST['TPL_timezone'] : '';
+          }
+        else
+          {
+        $selectsetting = $system->SETTINGS['timecorrection'];
+          }
+
 $time_correction = generateSelect('TPL_timezone', $TIMECORRECTION);
 
 $template->assign_vars(array(

--- a/register.php
+++ b/register.php
@@ -453,13 +453,7 @@ for ($i = 1; $i <= 31; $i++)
 }
 $dobday .= '</select>';
 
-if (isset($_POST['TPL_timezone'])) {
-        $selectsetting = (isset($_POST['TPL_timezone'])) ? $_POST['TPL_timezone'] : '';
-          }
-        else
-          {
-        $selectsetting = $system->SETTINGS['timecorrection'];
-          }
+$selectsetting = (isset($_POST['TPL_timezone'])) ? $_POST['TPL_timezone'] : $system->SETTINGS['timecorrection'];
 
 $time_correction = generateSelect('TPL_timezone', $TIMECORRECTION);
 


### PR DESCRIPTION
Default timezone can be set in settings but its not used on registration

it will just set the timezone based on the admin setting if it has not
been selected by the user already