### PR TITLE
Fix the reserve price bug

### DIFF
--- a/themes/default/sell.tpl
+++ b/themes/default/sell.tpl
@@ -6,20 +6,22 @@ $(document).ready(function(){
 	//sell javascript
 	$("#bn_only_no").click(function(){
 		$(".additional_shipping_costhide").hide();
-		$("#additional_shipping_cost").attr("disabled","disabled");
-		$("#min_bid").removeAttr("disabled");
-		$("#reserve_price").removeAttr("disabled");
-		$("#iqty").attr("disabled","disabled");
-		$("#iqty").val("1");
+	        $("#additional_shipping_cost").attr("disabled","disabled");
+	        $("#min_bid").removeAttr("disabled");
+	        $("#reserve_price").removeAttr("disabled");
+	        $("#with_reserve_yes").attr("checked", "checked");
+	        $("#iqty").attr("disabled","disabled");
+	        $("#iqty").val("1");
 	});
 	$("#bn_only_yes").click(function(){
 		$(".additional_shipping_costhide").show();
-		$("#additional_shipping_cost").removeAttr("disabled","disabled");
-		$("#min_bid").attr("disabled","disabled");
-		$("#reserve_price").attr("disabled","disabled");
-		$("#iqty").removeAttr("disabled");
-		$("#bn_yes").attr("checked", "checked");
-		$("#bn").removeAttr("disabled");
+	        $("#additional_shipping_cost").removeAttr("disabled","disabled");
+	        $("#min_bid").attr("disabled","disabled");
+	        $("#reserve_price").attr("disabled","disabled");
+	        $("#with_reserve_no").attr("checked", "checked");
+	        $("#iqty").removeAttr("disabled");
+	        $("#bn_yes").attr("checked", "checked");
+	        $("#bn").removeAttr("disabled");
 	});
 	$("#reserve_price").focus(function(){
 		$("#with_reserve_yes").attr("checked", "checked");


### PR DESCRIPTION
If the reserve price is selected before the Buy Now Only was selected, it caused an error and even if the reserve price was at zero. The error read "The Reserve price you entered is not correct". The error reported makes no sense and it really doesn't tell users to switch the reserve to  "no". This bug did not let the user proceed to sell the item until the reserve was switched to "no" if the user wanted to sell an item using the "buy now only. The fix here fixes that bug and will switch the reserve to the correct selection when the buy now is selected "yes" or "no".