### PR TITLE
Revert "Update addnew.tpl"

### DIFF
--- a/themes/admin/addnew.tpl
+++ b/themes/admin/addnew.tpl
@@ -44,7 +44,9 @@
                             </td>
                         </tr>
                     </table>
-
+<!-- IF ID ne '' -->
+                    <input type="hidden" name="id" value="{ID}">
+<!-- ENDIF -->
                     <input type="hidden" name="action" value="update">
                     <input type="hidden" name="csrftoken" value="{_CSRFTOKEN}">
                     <input type="submit" class="centre" value="{BUTTON}">


### PR DESCRIPTION
Reverts renlok/WeBid#114
Need to  revert this back. I have just discovered that the addnew.tpl is also used by the editnew.php and not only by the addnew.php.
The editnew.php needs the id var. Will just need to silence the error when addnew.php runs by assigning  'ID'=>'' in the template array. Will do at a later stage.