### PR TITLE
Update usergroups.php

### DIFF
--- a/admin/usergroups.php
+++ b/admin/usergroups.php
@@ -70,7 +70,7 @@ if (isset($_POST['action']))
 		}
 		$ERR = $ERR_050;
 	}
-	if ($_GET['action'] == 'edit' || is_numeric($_GET['id']))
+	if ($_GET['action'] == 'edit' || (isset($_GET['id']) && is_numeric($_GET['id'])))
 	{
 		$query = "UPDATE ". $DBPrefix . "groups SET
 				group_name = :group_name,


### PR DESCRIPTION
remove error Undefined id.
 Also this page could do with improving to prevent empty group names to be allowed and also to have some sort of delete user group button with allocation (of any users assigned to the deleted user group) to another group . Just concentrating on clearing errors at the moment. Improvements can come at a later date.