### PR TITLE
corrected improper use of "your"

### DIFF
--- a/language/EN/messages.inc.php
+++ b/language/EN/messages.inc.php
@@ -928,7 +928,7 @@ $MSG['863'] = '<h2>Not a Member yet?</h2>
         <p> Becoming a member enables you to:</p>
         <ul>
             <li>Sell anything</li>
-            <li>Be notified when an item your looking for is listed</li>
+            <li>Be notified when an item you are looking for is listed</li>
             <li>Add items to your watchlist</li>
             <li>Bid on items</li>
             <li>plus a whole lot more</li>


### PR DESCRIPTION
In line 931 above "your" was used instead of "you're" - to mean "you are."  I wasn't sure how to write "you're" without the apostrophe causing problems.