### PR TITLE
Country selection fix

### DIFF
--- a/language/EN/countries.inc.php
+++ b/language/EN/countries.inc.php
@@ -1,5 +1,6 @@
 <?php
 $countries = array(
+'' => '',
 'Afghanistan' => 'Afghanistan',
 'Albania' => 'Albania',
 'Algeria' => 'Algeria',


### PR DESCRIPTION
This fixes an adsearch bug. The Advanced Search was preselecting the Country Afghanistan instead of being blank causing problems with results. This will make the Country selection blank and will help out with Advanced Search Results.