### PR TITLE
Function Construct fixes

### DIFF
--- a/includes/class_fees.php
+++ b/includes/class_fees.php
@@ -20,7 +20,7 @@ class fees
 	var $data;
 	var $fee_types;
 
-	function fees()
+	function __construct()
 	{
 		$this->ASCII_RANGE = '1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 		$this->fee_types = $this->get_fee_types();

--- a/includes/functions_global.php
+++ b/includes/functions_global.php
@@ -21,7 +21,7 @@ class global_class
 {
 	var $SETTINGS, $ctime, $tdiff;
 
-	function global_class()
+	function __construct()
 	{
 		global $DBPrefix, $db;
 


### PR DESCRIPTION
Fixed the classes in both files as they where showing the following
errors.

Deprecated: Methods with the same name as their class will not be
constructors in a future version of PHP; global_class has a deprecated
constructor in
/home/auctions/public_html/webidnew/WeBid/includes/functions_global.php
on line 20

Deprecated: Methods with the same name as their class will not be
constructors in a future version of PHP; fees has a deprecated
constructor in
/home/auctions/public_html/webidnew/WeBid/includes/class_fees.php on
line 17