### PR TITLE
Allows .part to be removed on end of filename

### DIFF
--- a/includes/packages/PluploadHandler.php
+++ b/includes/packages/PluploadHandler.php
@@ -160,13 +160,12 @@ class PluploadHandler {
 					throw new Exception('', PLUPLOAD_SECURITY_ERR);
 				}
 
-				$final_file_path = strtolower($file_path);
-				rename($tmp_path, strtolower($final_file_path));
-
+				rename($tmp_path, $file_path);
+				
 				return array(
-					'name' => strtolower($file_name),
-					'path' => $final_file_path,
-					'size' => filesize($final_file_path)
+					'name' => $file_name,
+					'path' => $file_path,
+					'size' => filesize($file_path)
 				);
 			}
 


### PR DESCRIPTION
I dropped the strtolower after I tried to make it work but, it was causing the .part at the end of the filename to remain. Removing strtolower will allow the filename to be renamed to what it's supposed to be.