### PR TITLE
Fix recaptcha response not set error

### DIFF
--- a/register.php
+++ b/register.php
@@ -217,7 +217,8 @@ if (isset($_POST['action']) && $_POST['action'] == 'first')
 
 		if ($system->SETTINGS['spam_register'] == 2)
 		{
-			$resp = recaptcha_check_answer($system->SETTINGS['recaptcha_private'], $_POST['g-recaptcha-response']);
+			$recaptcha_response = (isset($_POST['g-recaptcha-response'])) ? $_POST['g-recaptcha-response'] : '';
+			$resp = recaptcha_check_answer($system->SETTINGS['recaptcha_private'], $recaptcha_response);
 		}
 
 		if ($system->SETTINGS['spam_register'] == 2 && !$resp)


### PR DESCRIPTION
Probably caused by attempted bot registration not setting the value....