### PR TITLE
wrap adjustment for item titles

### DIFF
--- a/themes/modern/css/style.css
+++ b/themes/modern/css/style.css
@@ -179,7 +179,7 @@
 	margin-bottom: 10px;
 }
 .feat-title {
-	white-space: nowrap;
+	white-space: normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin-top: 5px;


### PR DESCRIPTION
The item titles on the home page were running under the boxes. This way you can read the full titles.