### PR TITLE
Update functions_ajax.php

### DIFF
--- a/includes/functions_ajax.php
+++ b/includes/functions_ajax.php
@@ -82,9 +82,9 @@ function upload_images()
 			$fileName = $conf['file_name'];
 			// resize picture
 			$uploader->resizeThumbnailImage($targetDir . '/' . $fileName, $system->SETTINGS['gallery_max_width_height']);
-			if (!in_array($fileName, $_SESSION['UPLOADED_PICTURES']))
+			$final_file_name = strtolower($fileName);
+			if (!in_array($final_file_name, $_SESSION['UPLOADED_PICTURES']))
 			{
-				$final_file_name = strtolower($fileName);
 				array_push($_SESSION['UPLOADED_PICTURES'], $final_file_name);
 				if (count($_SESSION['UPLOADED_PICTURES']) == 1)
 				{


### PR DESCRIPTION
I have found a related problem in functions_ajax.php;

My scenario is uploading a 14MB picture to an auction with the name "testimage.JPG". As the image is uploaded and "chunked" out in 1MB chunks, functions_ajax.php was adding each chunk to the $_SESSION['UPLOADED_PICTURES']. So after uploading this image, my auction would show 14 instances of this picture because the filename was written to $_SESSION['UPLOADED_PICTURES'] as each "chunk" was written out. Here is the problem code in functions_ajax.php:

// resize picture
$uploader->resizeThumbnailImage($targetDir . '/' . $fileName, $system->SETTINGS['gallery_max_width_height']);
if (!in_array($fileName, $_SESSION['UPLOADED_PICTURES']))
{
$final_file_name = strtolower($fileName);
array_push($_SESSION['UPLOADED_PICTURES'], $final_file_name);
if (count($_SESSION['UPLOADED_PICTURES']) == 1)
{
$_SESSION['SELL_pict_url_temp'] = $_SESSION['SELL_pict_url'] = $final_file_name;
}
}

The problem is the code looks for $fileName in the array but then writes $final_file_name to the array if $fileName is not found. Obviously if $fileName does not equal $final_file_name this is a problem, and in fact in my case the $fileName ends with JPG and $final_file_name ends with jpg. So after each chunk, $final_file_name is added to the array. Here is the updated fixed code:

// resize picture
$uploader->resizeThumbnailImage($targetDir . '/' . $fileName, $system->SETTINGS['gallery_max_width_height']);
$final_file_name = strtolower($fileName);
if (!in_array($final_file_name, $_SESSION['UPLOADED_PICTURES']))
{
array_push($_SESSION['UPLOADED_PICTURES'], $final_file_name);
if (count($_SESSION['UPLOADED_PICTURES']) == 1)
{
$_SESSION['SELL_pict_url_temp'] = $_SESSION['SELL_pict_url'] = $final_file_name;
}
}