### PR TITLE
Update PluploadHandler.php

### DIFF
--- a/includes/packages/PluploadHandler.php
+++ b/includes/packages/PluploadHandler.php
@@ -330,7 +330,7 @@ class PluploadHandler {
 	 * operating systems and special characters requiring special escaping
 	 * to manipulate at the command line. Replaces spaces and consecutive
 	 * dashes with a single dash. Trim period, dash and underscore from beginning
-	 * and end of filename.
+	 * and end of filename.  Converts upper case characters to lower case.
 	 *
 	 * @author WordPress
 	 *
@@ -343,6 +343,7 @@ class PluploadHandler {
 	    $filename = str_replace($special_chars, '', $filename);
 	    $filename = preg_replace('/[\s-]+/', '-', $filename);
 	    $filename = trim($filename, '.-_');
+	    $filename = strtolower($filename);
 	    return $filename;
 	}
 


### PR DESCRIPTION
Resolves Open Issue 261, in a slightly different fashion by "normalizing" the filename instead of using "strtolower" on the $file_path.

Uploaded images sometimes have UPPER CASE file extension, does not match WeBid URL -- Open issue #261