### PR TITLE
Debug mode for error reporting

### DIFF
--- a/common.php
+++ b/common.php
@@ -16,6 +16,7 @@ session_start();
 date_default_timezone_set('UTC'); // to make times more consistent
 $error_reporting = E_ALL^E_NOTICE;
 $error_reporting = E_ALL; // use this for debugging
+define('WeBidDebug', false); // use this for debugging
 define('InWeBid', true);
 define('TrackUserIPs', true);
 

--- a/includes/database/DatabasePDO.php
+++ b/includes/database/DatabasePDO.php
@@ -23,6 +23,7 @@ class DatabasePDO extends Database
         'FETCH_BOTH' => PDO::FETCH_BOTH,
         'FETCH_NUM' => PDO::FETCH_NUM,
     ];
+    protected $error_supress = !WeBidDebug;
 
     public function connect($DbHost, $DbUser, $DbPassword, $DbDatabase, $DBPrefix, $CHARSET = 'UTF-8')
     {
@@ -212,9 +213,8 @@ class DatabasePDO extends Database
     protected function error_handler($error)
     {
         if (!$this->error_supress) {
-            // TODO: make this better
-            $this->error = debug_backtrace();
-            trigger_error($this->error, E_USER_ERROR);
+            trigger_error($error, E_USER_WARNING);
+            debug_print_backtrace();
         }
     }
 

--- a/includes/errors.inc.php
+++ b/includes/errors.inc.php
@@ -20,19 +20,46 @@ function WeBidErrorHandler($errno, $errstr, $errfile, $errline)
 {
     global $system, $_SESSION;
     switch ($errno) {
+        case E_ERROR:
+            $error = "<b>Fatal error</b> [$errno] $errstr\n";
+            $error .= "  Fatal error on line $errline in file $errfile";
+            $error .= ", PHP " . PHP_VERSION . " (" . PHP_OS . ")\n";
+            $error .= "Aborting...\n";
+            break;
+
+        case E_WARNING:
+            $error = "<b>Warning</b> [$errno] $errstr on $errfile line $errline\n";
+            break;
+
+        case E_NOTICE:
+            $error = "<b>Notice</b> [$errno] $errstr on $errfile line $errline\n";
+            break;
+
         case E_USER_ERROR:
-            $error = "<b>My ERROR</b> [$errno] $errstr\n";
+            $error = "<b>Fatal error trigger</b> [$errno] $errstr\n";
             $error .= "  Fatal error on line $errline in file $errfile";
             $error .= ", PHP " . PHP_VERSION . " (" . PHP_OS . ")\n";
             $error .= "Aborting...\n";
             break;
 
         case E_USER_WARNING:
-            $error = "<b>My WARNING</b> [$errno] $errstr on $errfile line $errline\n";
+            $error = "<b>Warning trigger</b> [$errno] $errstr on $errfile line $errline\n";
             break;
 
         case E_USER_NOTICE:
-            $error = "<b>My NOTICE</b> [$errno] $errstr on $errfile line $errline\n";
+            $error = "<b>Notice trigger</b> [$errno] $errstr on $errfile line $errline\n";
+            break;
+
+        case E_STRICT:
+            $error = "<b>Strict notice</b> [$errno] $errstr on $errfile line $errline\n";
+            break;
+
+        case E_DEPRECATED:
+            $error = "<b>Deprecated notice</b> [$errno] $errstr on $errfile line $errline\n";
+            break;
+
+        case E_USER_DEPRECATED:
+            $error = "<b>Deprecated notice trigger</b> [$errno] $errstr on $errfile line $errline\n";
             break;
 
         default:
@@ -45,7 +72,12 @@ function WeBidErrorHandler($errno, $errstr, $errfile, $errline)
     $_SESSION['SESSION_ERROR'][] = $error;
     // log the error
     $system->log('error', $error);
-    if ($errno == E_USER_ERROR) {
+
+    if (WeBidDebug) {
+        echo $error;
+    }
+
+    if ($errno | E_USER_ERROR || $errno | E_ERROR) {
         exit(1);
     }
     return true;


### PR DESCRIPTION
Having errors show up while developing is more useful than logging
them, since you're more likely to notice they're there.

As proof of this, the front page of the control panel has had a
broken SQL query for a very long time. Now you know!