### PR TITLE
Removed B_HIGHLIGHTED

### DIFF
--- a/themes/modern/browse.tpl
+++ b/themes/modern/browse.tpl
@@ -12,7 +12,7 @@
 				<th width="18%" class="tr-timeleft hidden-xs"> <small>{L_171}</small></th>
 			</tr>
 	<!-- BEGIN featured_items -->
-			<tr align="center"<!-- IF featured_items.B_HIGHLIGHTED --> bgcolor="#fea100"<!-- ELSEIF (featured_items.S_ROW_COUNT % 2) == 1 --> bgcolor="#FFFEEE"<!-- ENDIF -->>
+			<tr align="center">
 				<td align="center">
 					<a href="{SITEURL}item.php?id={featured_items.ID}"><img class="search-res img-rounded" src="{featured_items.IMAGE}" border="0"></a>
 				</td>
@@ -53,7 +53,7 @@
 				<th width="18%" class="tr-timeleft hidden-xs"> <small>{L_171}</small></th>
 			</tr>
 <!-- BEGIN items -->
-			<tr align="center"<!-- IF items.B_HIGHLIGHTED --> bgcolor="#fea100"<!-- ELSEIF (items.S_ROW_COUNT % 2) == 1 --> bgcolor="#FFFEEE"<!-- ENDIF -->>
+			<tr align="center">
 				<td align="center">
 					<a href="{SITEURL}item.php?id={items.ID}"><img class="search-res img-rounded" src="{items.IMAGE}" border="0"></a>
 				</td>


### PR DESCRIPTION
This was causing Unknown error type: [8] Undefined index: B_HIGHLIGHTED when running search, advanced search when finding items and also when clicking a category with items.. It's not in any of the old scripts that I checked. For some reason it was added to the modern theme. Removing it will stop all of the errors that pop up in the error log.