### PR TITLE
Version checker updates.

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -133,21 +133,25 @@ if ($system->SETTINGS['activationtype'] == 0) {
 }
 
 // version check
-switch ($system->SETTINGS['version_check']) {
-    default:
-        $url = 'http://raw.githubusercontent.com/renlok/WeBid/master/install/thisversion.txt';
-        break;
-}
+$realversion = '0.0';
+$update_available = false;
 
-if (!($realversion = load_file_from_url($url))) {
+if ($system->SETTINGS['version_check'] != '') {
+  switch ($system->SETTINGS['version_check']) {
+    default:
+      $url = 'http://raw.githubusercontent.com/renlok/WeBid/master/install/thisversion.txt';
+        break;
+  }
+
+  if (!($realversion = load_file_from_url($url))) {
     $ERR = $MSG['error_file_access_disabled'];
     $realversion = $MSG['unknown'];
-}
+  }
 
-$update_available = false;
-if (version_compare($system->SETTINGS['version'], $realversion, "<")) {
+  if (version_compare($system->SETTINGS['version'], $realversion, "<")) {
     $update_available = true;
     $text = $MSG['outdated_version'];
+  }
 }
 
 //getting the correct email settings

--- a/admin/index.php
+++ b/admin/index.php
@@ -134,11 +134,8 @@ if ($system->SETTINGS['activationtype'] == 0) {
 
 // version check
 switch ($system->SETTINGS['version_check']) {
-    case 'unstable':
-        $url = 'http://www.webidsupport.com/version_unstable.txt';
-        break;
     default:
-        $url = 'http://www.webidsupport.com/version.txt';
+        $url = 'http://raw.githubusercontent.com/renlok/WeBid/master/install/thisversion.txt';
         break;
 }
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -136,7 +136,7 @@ if ($system->SETTINGS['activationtype'] == 0) {
 $realversion = '0.0';
 $update_available = false;
 
-if ($system->SETTINGS['version_check'] != '') {
+if ($system->SETTINGS['version_check'] !== "") {
   switch ($system->SETTINGS['version_check']) {
     default:
       $url = 'http://raw.githubusercontent.com/renlok/WeBid/master/install/thisversion.txt';


### PR DESCRIPTION
Lets check the version from github as webidsupport.com/version.txt isn't maintained anymore.
Unstable option removed as renlok does not keep multiple branches currently.
@renlok - we could use branches to allow different release types (stable/unstable/alpha/beta etc...).
Adding ability to disable the update check