### PR TITLE
Time adjustment

### DIFF
--- a/includes/functions_sell.php
+++ b/includes/functions_sell.php
@@ -240,7 +240,7 @@ function updateauction()
     $params[] = array(':shipping', $_SESSION['SELL_shipping'], 'int');
     $params[] = array(':payment', $payment_text, 'str');
     $params[] = array(':international', $_SESSION['SELL_international'], 'bool');
-    $params[] = array(':ends', $dt->convertToUTC($a_ends), 'str');
+    $params[] = array(':ends', ($a_ends), 'str');
     $params[] = array(':photo_uploaded', $_SESSION['SELL_file_uploaded'], 'bool');
     $params[] = array(':initial_quantity', $_SESSION['SELL_iquantity'], 'int');
     $params[] = array(':quantity', $_SESSION['SELL_iquantity'], 'int');
@@ -255,7 +255,7 @@ function updateauction()
     $params[] = array(':auction_id', $_SESSION['SELL_auction_id'], 'int');
     if ($caneditstartdate) {
         $query .= ", starts = :starts";
-        $params[] = array(':starts', $dt->convertToUTC($a_starts), 'str');
+        $params[] = array(':starts', ($a_starts), 'str');
     }
     $query .= ' WHERE id = :auction_id';
     $db->query($query, $params);
@@ -272,7 +272,7 @@ function addauction()
     $params[] = array(':user_id', $user->user_data['id'], 'int');
     $params[] = array(':title', $_SESSION['SELL_title'], 'str');
     $params[] = array(':subtitle', $_SESSION['SELL_subtitle'], 'str');
-    $params[] = array(':starts', $dt->convertToUTC($a_starts), 'str');
+    $params[] = array(':starts', ($a_starts), 'str');
     $params[] = array(':description', $_SESSION['SELL_description'], 'str');
     $params[] = array(':pict_url', $_SESSION['SELL_pict_url'], 'str');
     $params[] = array(':catone', $_SESSION['SELL_sellcat1'], 'int');
@@ -288,7 +288,7 @@ function addauction()
     $params[] = array(':shipping', $_SESSION['SELL_shipping'], 'int');
     $params[] = array(':payment', $payment_text, 'str');
     $params[] = array(':international', $_SESSION['SELL_international'], 'bool');
-    $params[] = array(':ends', $dt->convertToUTC($a_ends), 'str');
+    $params[] = array(':ends', ($a_ends), 'str');
     $params[] = array(':photo_uploaded', $_SESSION['SELL_file_uploaded'], 'bool');
     $params[] = array(':initial_quantity', $_SESSION['SELL_iquantity'], 'int');
     $params[] = array(':quantity', $_SESSION['SELL_iquantity'], 'int');


### PR DESCRIPTION
The removal of the parts of the codes will allow the user's newly submitted items to be inserted into the database at their correct timezone instead of UTC's timezone. For me the UTC timezone is 4 hours ahead of my EST timezone so, it caused my newly submitted auctions to be pending for 4 hours. There was also two time conversions on each of the lines adjusted. For instance the $a_starts & $a_ends has convertToDatetime in it's definition. Timezone will adjust correctly with whatever timezone the user chooses with the  code this way. The other way, timezones won't adjust at all on newly submitted items.