### PR TITLE
Require the installation of GC Math for installation

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -218,14 +218,15 @@ function show_config_table($fresh = true)
             );
 
         umask(0);
-
+        //Check wether the BC Math extension is installed
+        $bcinstalled = true;
+        if(!extension_loaded('bcmath')){
+            $bcinstalled = false;
+        }
         $passed = true;
         foreach ($directories as $dir) {
             $exists = $write = false;
-            //Check wether the BC Math extension is installed
-            if(!(extension_loaded('bcmath'))){
-                $bcinstalled = false;
-            }
+            
             // Try to create the directory if it does not exist
             if (!file_exists(MAIN_PATH . $dir)) {
                 @mkdir(MAIN_PATH . $dir, 0755);

--- a/install/functions.php
+++ b/install/functions.php
@@ -222,7 +222,10 @@ function show_config_table($fresh = true)
         $passed = true;
         foreach ($directories as $dir) {
             $exists = $write = false;
-
+            //Check wether the BC Math extension is installed
+            if(!(extension_loaded('bcmath'))){
+                $bcinstalled = false;
+            }
             // Try to create the directory if it does not exist
             if (!file_exists(MAIN_PATH . $dir)) {
                 @mkdir(MAIN_PATH . $dir, 0755);
@@ -243,7 +246,7 @@ function show_config_table($fresh = true)
 
             @unlink(MAIN_PATH . $dir . 'test_lock');
 
-            if (!$exists || !$write) {
+            if (!$exists || !$write || !$bcinstalled) {
                 $passed = false;
             }
 

--- a/install/functions.php
+++ b/install/functions.php
@@ -218,11 +218,6 @@ function show_config_table($fresh = true)
             );
 
         umask(0);
-        //Check wether the BC Math extension is installed
-        $bcinstalled = true;
-        if(!extension_loaded('bcmath')){
-            $bcinstalled = false;
-        }
         $passed = true;
         foreach ($directories as $dir) {
             $exists = $write = false;
@@ -247,7 +242,7 @@ function show_config_table($fresh = true)
 
             @unlink(MAIN_PATH . $dir . 'test_lock');
 
-            if (!$exists || !$write || !$bcinstalled) {
+            if (!$exists || !$write || !extension_loaded('bcmath')) {
                 $passed = false;
             }
 


### PR DESCRIPTION
Currently GC Math is not required for installation which causes sell.php to have a blank page as it is trying to call GC Math on line 565.