### PR TITLE
 alteration to stop backbutton or refresh deleting img and multipling…

### DIFF
--- a/sell.php
+++ b/sell.php
@@ -304,7 +304,7 @@ switch ($_SESSION['action']) {
                     'TITLE' => $MSG['028'],
                     'PAGE' => 3,
                     'AUCTION_ID' => $auction_id,
-                    'MESSAGE' => sprintf($MSG['102'], $auction_id, $dt->formatDate($a_ends, 'D j M \a\t g:ia'))
+                    'REDIRECT' => header('location: sellsuccess.php?is=done&item='.$auction_id.'&time='.$a_ends.'&duration='.$duration.''),
                     ));
             break;
         }


### PR DESCRIPTION
… fees.

when auction is successfully listed at the moment and the black button is pressed or refreshed the image gets lost and if fees are enabled for that auction, they multiple on every refresh. this is what i came up with stop the problem