### PR TITLE
 alteration to stop backbutton or refresh deleting img and multipling…

### DIFF
--- a/themes/classic/sell.tpl
+++ b/themes/classic/sell.tpl
@@ -699,15 +699,7 @@ $(document).ready(function(){
 				</div>
 			</form>
 <!-- ELSE -->
-			<div class="padding">
-				{L_100}
-				<p>{MESSAGE}</p>
-				<ul>
-					<li><a href="{SITEURL}item.php?id={AUCTION_ID}&mode=1">{L_101}</a></li>
-					<li><a href="{SITEURL}edit_active_auction.php?id={AUCTION_ID}">{L_30_0069}</a></li>
-					<li><a href="{SITEURL}sellsimilar.php?id={AUCTION_ID}">{L_2__0050}</a></li>
-				</ul>
-			</div>
+			{REDIRECT}
 <!-- ENDIF -->
 		</div>
 	</div>


### PR DESCRIPTION
… fees.

when auction is successfully listed at the moment and the black button is pressed or refreshed the image gets lost and if fees are enabled for that auction, they multiple on every refresh. this is what i came up with stop the problem