### PR TITLE
 alteration to stop backbutton or refresh deleting img and multipling…

### DIFF
--- a/themes/modern/sellsuccess.tpl
+++ b/themes/modern/sellsuccess.tpl
@@ -1,0 +1,18 @@
+<div class="row">
+    <div class="col-md-12">
+        <div class="col-md-8 col-md-offset-2 well ">
+            <legend>{L_028}</legend>
+            <div class="table2 add_item">
+                   <div class="padding">
+                    {L_100}
+                    <p>{MESSAGE}</p>
+                    <ul>
+                        <li><a href="{SITEURL}item.php?id={AUCTION_ID}&mode=1">{L_101}</a></li>
+                        <li><a href="{SITEURL}edit_active_auction.php?id={AUCTION_ID}">{L_30_0069}</a></li>
+                        <li><a href="{SITEURL}sellsimilar.php?id={AUCTION_ID}">{L_2__0050}</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+   </div>
+</div>


### PR DESCRIPTION
… fees.

when auction is successfully listed at the moment and the black button is pressed or refreshed the image gets lost and if fees are enabled for that auction, they multiple on every refresh. this is what i came up with stop the problem