### PR TITLE
alteration to stop backbutton or refresh deleting img and multipling …

### DIFF
--- a/sellsuccess.php
+++ b/sellsuccess.php
@@ -1,0 +1,36 @@
+<?php
+include 'common.php';
+include INCLUDE_PATH . 'functions_sell.php';
+
+// Stop back button killing auction
+if (isset($_SESSION['previous'])) {
+   if (basename($_SERVER['PHP_SELF']) != $_SESSION['previous']) {
+        ### unset variable to stop back button
+        unset($_SESSION['SELL_auction_id']);
+       //header('location: user_menu.php');
+   }
+}
+
+if(isset($_GET['is'], $_GET['item'], $_GET['time'], $_GET['duration'])){
+       $is = $_GET['is'];
+       $auction_id = $_GET['item'];
+       $a_ends = $_GET['time'];
+    
+
+    
+    switch($is){
+        case 'done':
+    
+        $template->assign_vars(array(
+                    'AUCTION_ID' => $auction_id,
+                    'MESSAGE' => sprintf($MSG['102'], $auction_id, $dt->formatDate($a_ends, 'D j M \a\t g:ia'))
+                    ));
+        break;
+        }
+}
+include 'header.php';
+$template->set_filenames(array(
+        'body' => 'sellsuccess.tpl'
+        ));
+$template->display('body');
+include 'footer.php';


### PR DESCRIPTION
…fees.

when auction is successfully listed at the moment and the black button is pressed or refreshed the image gets lost and if fees are enabled for that auction, they multiple on every refresh. this is what i came up with stop the problem