### PR TITLE
Admin payments methods crashes

### DIFF
--- a/admin/payments.php
+++ b/admin/payments.php
@@ -21,7 +21,7 @@ include 'loggedin.inc.php';
 if (isset($_POST['action']) && $_POST['action'] == 'update') {
     if (isset($_POST['payment'])) {
         foreach ($_POST['payment'] as $payment_id => $payment) {
-            if (in_array($payment_id, $_POST['delete'])) {
+            if (isset($_POST['delete']) && in_array($payment_id, $_POST['delete'])) {
                 $query = "DELETE FROM " . $DBPrefix . "payment_options WHERE id = :id";
                 $params = [[':id', $payment['id'], 'int']];
                 $db->query($query, $params);


### PR DESCRIPTION
Standard behavior for browsers is to only sent a value if the checkbox is checked (as per HTML 4 recommendation). When (on submit) none of the "delete[]" checkboxes is checked, PHP fails with an 'Undefined index: delete' error. Fix by adding a check if it is set.