### PR TITLE
Item view counter MySQL error

### DIFF
--- a/item.php
+++ b/item.php
@@ -52,7 +52,7 @@ $customincrement = $auction_data['increment'];
 $seller_reg = $dt->formatDate($auction_data['reg_date']);
 
 // sort out counter
-if (empty($auction_data['counter'])) {
+if (!isset($auction_data['counter'])) {
     $query = "INSERT INTO `" . $DBPrefix . "auccounter` (`auction_id`, `counter`) VALUES (:counter, 1)";
     $params = array();
     $params[] = array(':counter', $id, 'int');


### PR DESCRIPTION
When a counter is set to zero, empty($auction_data['counter']) returns true so an 'INSERT INTO' is run, resulting in an MySQL error " SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'XXX' for key 'PRIMARY'". Fixed by checking if it is set instead of being empty.