### PR TITLE
Category selection remains stuck at top category

### DIFF
--- a/select_category.php
+++ b/select_category.php
@@ -30,7 +30,7 @@ if (!$user->permissions['can_sell']) {
 }
 
 // Process category selection
-$box = (isset($_POST['box']) && !empty($_POST['box'])) ? $_POST['box'] + 1 : 0;
+$box = (isset($_POST['box'])) ? $_POST['box'] + 1 : 0;
 $catscontrol = new MPTTcategories();
 $cat_no = (isset($_REQUEST['cat_no'])) ? $_REQUEST['cat_no'] : 1;
 $i = 0;


### PR DESCRIPTION
When $_POST['box'] is zero, empty($_POST['box']) returns true and $_POST['box'] is set to 0. This causes the category selection procedure to remain stuck at the top category selection. This fix removes the check (effectively reverting commit 9ab622db4e89443fa3d6242f09f0645138f908c7).