### PR TITLE
Submitted auction not stored in database

### DIFF
--- a/sell.php
+++ b/sell.php
@@ -112,6 +112,9 @@ switch ($_SESSION['action']) {
                     updateauction();
                     $auction_id = $_SESSION['SELL_auction_id'];
                 } else {
+                    if (empty($_SESSION['SELL_relist'])) {
+                        $_SESSION['SELL_relist'] = 0;
+                    }
                     // insert auction
                     addauction();
                     $auction_id = $db->lastInsertId();


### PR DESCRIPTION
When auto relist is disabled, $_SESSION['SELL_relist'] is '', causing the insert into the database to fail with SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'relist' at row 1. Fixed by forcing an empty value to 0.