### PR TITLE
Image resolution for item view too low

### DIFF
--- a/getthumb.php
+++ b/getthumb.php
@@ -21,6 +21,7 @@ $nomanage = false;
 $accepted_widths = array(
     $system->SETTINGS['thumb_show'],
     $system->SETTINGS['thumb_list'],
+    430,
     '' // load default image
 );
 $w = (in_array($w, $accepted_widths)) ? $w : '';

--- a/themes/modern/item.tpl
+++ b/themes/modern/item.tpl
@@ -55,7 +55,7 @@ $(document).ready(function() {
 					<div class="panel-heading"><span class="label label-default">{L_113}: {ID}</span></div>
 					<div class="panel-body">
 						<div class="col-md-12">
-							<img class="img-rounded img-responsive center-block" src="{SITEURL}getthumb.php?w={THUMBWIDTH}&fromfile={PIC_URL}" border="0" align="center" width="430px">
+							<img class="img-rounded img-responsive center-block" src="{SITEURL}getthumb.php?w=430&fromfile={PIC_URL}" border="0" align="center" width="430px">
 						</div>
 	<!-- IF B_HASGALELRY -->
 						<div>


### PR DESCRIPTION
The modern theme hardcodes image width to 430px so we should provide thumbnails that match that