### PR TITLE
Fix database errors when newsletter is not enabled

### DIFF
--- a/edit_data.php
+++ b/edit_data.php
@@ -101,7 +101,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'update') {
             $params[] = array(':phone', $system->cleanvars($_POST['TPL_phone']), 'str');
             $params[] = array(':timezone', $_POST['TPL_timezone'], 'str');
             $params[] = array(':emailtype', $system->cleanvars($_POST['TPL_emailtype']), 'str');
-            $params[] = array(':nletter', $system->cleanvars($_POST['TPL_nletter']), 'str');
+            $params[] = array(':nletter', intval($_POST['TPL_nletter']), 'int');
 
             if (strlen($_POST['TPL_password']) > 0) {
                 // hash the password

--- a/register.php
+++ b/register.php
@@ -269,7 +269,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'first') {
                     array(':country', $system->cleanvars((isset($_POST['TPL_country'])) ? $_POST['TPL_country'] : ''), 'str'),
                     array(':zip', $system->cleanvars((isset($_POST['TPL_zip'])) ? $_POST['TPL_zip'] : ''), 'str'),
                     array(':phone', $system->cleanvars((isset($_POST['TPL_phone'])) ? $_POST['TPL_phone'] : ''), 'str'),
-                    array(':nletter', $_POST['TPL_nletter'], 'int'),
+                    array(':nletter', intval($_POST['TPL_nletter']), 'int'),
                     array(':email', $system->cleanvars($_POST['TPL_email']), 'str'),
                     array(':birthdate', ((!empty($DATE)) ? $DATE : 0), 'str'),
                     array(':suspended', $SUSPENDED, 'int'),


### PR DESCRIPTION
The database nletter type is tinyint. When the newsletter is not enabled, TPL_nletter is unset, which causes an "Integrity constraint violation: 1048 Column 'nletter' cannot be null" when inserting into or updating the database. Convert to int (intval will return 0 for an empty value).