### PR TITLE
Fix for SQL_MODE ONLY_FULL_GROUP_BY

### DIFF
--- a/admin/listclosedauctions.php
+++ b/admin/listclosedauctions.php
@@ -46,7 +46,7 @@ $query = "SELECT a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_nam
           LEFT JOIN " . $DBPrefix . "winners w ON (w.auction = a.id)
           LEFT JOIN " . $DBPrefix . "reportedauctions r ON (a.id = r.auction_id)
           LEFT JOIN " . $DBPrefix . "auction_moderation m ON (a.id = m.auction_id)
-          WHERE m.reason IS NULL AND a.closed = 1 AND a.suspended = 0 GROUP BY a.id ORDER BY nick LIMIT :offset, :perpage";
+          WHERE m.reason IS NULL AND a.closed = 1 AND a.suspended = 0 GROUP BY a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_name, m.reason ORDER BY nick LIMIT :offset, :perpage";
 $params = array();
 $params[] = array(':offset', $OFFSET, 'int');
 $params[] = array(':perpage', $system->SETTINGS['perpage'], 'int');

--- a/admin/listreportedauctions.php
+++ b/admin/listreportedauctions.php
@@ -49,7 +49,7 @@ $query = "SELECT a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_nam
           LEFT JOIN " . $DBPrefix . "categories c ON (c.cat_id = a.category)
           INNER JOIN " . $DBPrefix . "reportedauctions r ON (a.id = r.auction_id)
           LEFT JOIN " . $DBPrefix . "auction_moderation m ON (a.id = m.auction_id)
-          WHERE m.reason IS NULL AND a.closed = 0 AND a.suspended = 0 " . $user_sql . " GROUP BY a.id ORDER BY nick LIMIT :offset, :perpage";
+          WHERE m.reason IS NULL AND a.closed = 0 AND a.suspended = 0 " . $user_sql . " GROUP BY a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_name, m.reason ORDER BY nick LIMIT :offset, :perpage";
 $params = array();
 $params[] = array(':offset', $OFFSET, 'int');
 $params[] = array(':perpage', $system->SETTINGS['perpage'], 'int');

--- a/admin/listsuspendedauctions.php
+++ b/admin/listsuspendedauctions.php
@@ -41,12 +41,12 @@ $db->direct_query($query);
 $num_auctions = $db->result('auctions');
 $PAGES = ($num_auctions == 0) ? 1 : ceil($num_auctions / $system->SETTINGS['perpage']);
 
-$query = "SELECT a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_name, COUNT(r.id) as times_reported, m.reason  FROM " . $DBPrefix . "auctions a
+$query = "SELECT a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_name, COUNT(r.id) as times_reported, m.reason FROM " . $DBPrefix . "auctions a
           LEFT JOIN " . $DBPrefix . "users u ON (u.id = a.user)
           LEFT JOIN " . $DBPrefix . "categories c ON (c.cat_id = a.category)
           LEFT JOIN " . $DBPrefix . "reportedauctions r ON (a.id = r.auction_id)
           LEFT JOIN " . $DBPrefix . "auction_moderation m ON (a.id = m.auction_id)
-          WHERE m.reason IS NULL AND a.suspended != 0  GROUP BY a.id ORDER BY nick LIMIT :offset, :perpage";
+          WHERE m.reason IS NULL AND a.suspended != 0  GROUP BY a.id, u.nick, a.title, a.starts, a.ends, a.suspended, c.cat_name, m.reason ORDER BY nick LIMIT :offset, :perpage";
 $params = array();
 $params[] = array(':offset', $OFFSET, 'int');
 $params[] = array(':perpage', $system->SETTINGS['perpage'], 'int');


### PR DESCRIPTION
Since MySQL 5.7, SQL_MODE ONLY_FULL_GROUP_BY is enabled by default, causing the query to fail. This fixes the query.