### PR TITLE
Fix platform string length

### DIFF
--- a/includes/stats.inc.php
+++ b/includes/stats.inc.php
@@ -156,6 +156,7 @@ if ($STATSSETTINGS['activate'] == 'y') {
     } else {
         $os .=  strtoupper($browser_info[6]);
     }
+    $os = substr($os, 0, 50);
 
     $browser = '';
     if ($browser_info[0] == 'moz') {


### PR DESCRIPTION
The length of $os can exceed 50 characters, causing the "String data, right truncated: 1406 Data too long for column 'platform'" database error. Fix by truncating to 50 characters.