### PR TITLE
Fix logic for aborting on error

### DIFF
--- a/includes/errors.inc.php
+++ b/includes/errors.inc.php
@@ -77,7 +77,7 @@ function WeBidErrorHandler($errno, $errstr, $errfile, $errline)
         echo $error;
     }
 
-    if ($errno | E_USER_ERROR || $errno | E_ERROR) {
+    if ($errno & (E_ERROR|E_USER_ERROR)) {
         exit(1);
     }
     return true;


### PR DESCRIPTION
The check E_*ERROR would always be true, so every error, even only notices or warnings, would cause execution to be aborted. Fixed so only real errors stop execution.