### PR TITLE
Log database errors

### DIFF
--- a/includes/database/DatabasePDO.php
+++ b/includes/database/DatabasePDO.php
@@ -57,7 +57,7 @@ class DatabasePDO extends Database
         }
     }
 
-    // put together the quert ready for running
+    // put together the query ready for running
     /*
     $query must be given like SELECT * FROM table WHERE this = :that AND where = :here
     then $params would holds the values for :that and :here, $table would hold the vlue for :table
@@ -212,8 +212,8 @@ class DatabasePDO extends Database
 
     protected function error_handler($error)
     {
+        trigger_error($error, E_USER_WARNING);
         if (!$this->error_supress) {
-            trigger_error($error, E_USER_WARNING);
             debug_print_backtrace();
         }
     }


### PR DESCRIPTION
By default (i.e. without debugging turned on) database query errors are ignored silently. I strongly suggest to at least log these errors so the admin is made aware and can further debug the problem.

To make this really usable for debugging, it might be necessary to include the backtrace (hidden) in the log entry?
trigger_error($error . '<!--' . print_r(debug_backtrace(), true) . '-->', E_USER_WARNING);