### PR TITLE
Set time zone of database connection to UTC

### DIFF
--- a/common.php
+++ b/common.php
@@ -56,6 +56,7 @@ if (isset($CHARSET)) {
 } else {
     $db->connect($DbHost, $DbUser, $DbPassword, $DbDatabase, $DBPrefix);
 }
+$db->direct_query("SET time_zone = '+0:00'");
 
 $system = new global_class();
 $template = new Template();


### PR DESCRIPTION
On retrieval, the database automatically converts TIMESTAMPs to the time zone of the connection (by default the time zone of the database server). WeBid treats these times as UTC, so set the time zone of the connection to UTC.