### PR TITLE
Fix GROUP BY clause

### DIFF
--- a/yourauctions_sold.php
+++ b/yourauctions_sold.php
@@ -172,7 +172,7 @@ $query = "SELECT a.* FROM " . $DBPrefix . "auctions a
 	WHERE a.user = :user_id
 	AND a.closed = 1
 	AND a.suspended = 0
-	GROUP BY w.auction
+	GROUP BY a.id
 	ORDER BY " . $_SESSION['solda_ord'] . " " . $_SESSION['solda_type'] . " LIMIT :offset, :perpage";
 $params = array();
 $params[] = array(':user_id', $user->user_data['id'], 'int');


### PR DESCRIPTION
Fix for error "SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'auction.a.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by"