### PR TITLE
Fix DISTINCT error

### DIFF
--- a/buying.php
+++ b/buying.php
@@ -52,7 +52,7 @@ if (!isset($_GET['PAGE']) || intval($_GET['PAGE']) <= 1 || empty($_GET['PAGE']))
 $PAGES = ($TOTALAUCTIONS == 0) ? 1 : ceil($TOTALAUCTIONS / $system->SETTINGS['perpage']);
 
 // Get closed auctions with winners
-$query = "SELECT DISTINCT a.id, a.qty, a.seller, a.paid, a.feedback_win, a.bid, a.auction, a.shipped, b.title, b.ends, b.shipping_cost, b.additional_shipping_cost, b.shipping, u.nick, u.email
+$query = "SELECT DISTINCT a.id, a.qty, a.seller, a.paid, a.feedback_win, a.bid, a.auction, a.shipped, a.closingdate, b.title, b.ends, b.shipping_cost, b.additional_shipping_cost, b.shipping, u.nick, u.email
 		FROM " . $DBPrefix . "winners a
 		LEFT JOIN " . $DBPrefix . "auctions b ON (a.auction = b.id)
 		LEFT JOIN " . $DBPrefix . "users u ON (u.id = a.seller)


### PR DESCRIPTION
Fix error "SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column 'auction.a.closingdate' which is not in SELECT list; this is incompatible with DISTINCT"