### PR TITLE
Fix reuse of conditional variable inside loop

### DIFF
--- a/admin/deleteuser.php
+++ b/admin/deleteuser.php
@@ -104,6 +104,7 @@ if (isset($_POST['action']) && $_POST['action'] == "Yes") {
         $bid_data = $db->fetchall();
         foreach ($bid_data as $row) {
             $params = array();
+            $extra = '';
             // check if user is highest bidder
             if ($row['current_bid'] == $row['bid']) {
                 $query = "SELECT bid FROM " . $DBPrefix . "bids WHERE auction = :auc_id ORDER BY bid DESC LIMIT 1, 1";


### PR DESCRIPTION
$extra was not being (re)initialized at the start of each iteration, so once it was set it would remain set in all following iterations. This would cause those queries to fail because of missing parameters. Fix by (re)setting $extra to empty at the start of each iteration.