### PR TITLE
Fix formatTimeLeft minutes

### DIFF
--- a/includes/Date.php
+++ b/includes/Date.php
@@ -113,9 +113,9 @@ class Date
             if ($diff->h > 0) {
                 $timeleft .= $diff->h . $MSG['hour_short'] . ' ';
             }
-            if ($diff->m > 0) {
-                $timeleft .= $diff->m . $MSG['minute_short'] . ' ';
-            } elseif ($diff->h == 0 && $diff->m == 0 && $diff->s > 0) {
+            if ($diff->i > 0) {
+                $timeleft .= $diff->i . $MSG['minute_short'] . ' ';
+            } elseif ($diff->h == 0 && $diff->i == 0 && $diff->s > 0) {
                 $timeleft = '<1' . $MSG['minute_short'];
             }
             if ($diff->invert) {


### PR DESCRIPTION
formatTimeLeft was using the month value for the minutes left. Fixed to use the DateInterval i (minutes) value.