### PR TITLE
Fix current_bid_id after user delete

### DIFF
--- a/admin/deleteuser.php
+++ b/admin/deleteuser.php
@@ -107,15 +107,15 @@ if (isset($_POST['action']) && $_POST['action'] == "Yes") {
             $extra = '';
             // check if user is highest bidder
             if ($row['current_bid'] == $row['bid']) {
-                $query = "SELECT bid FROM " . $DBPrefix . "bids WHERE auction = :auc_id ORDER BY bid DESC LIMIT 1, 1";
+                $query = "SELECT id, bid FROM " . $DBPrefix . "bids WHERE auction = :auc_id ORDER BY bid DESC LIMIT 1, 1";
                 $params[] = array(':auc_id', $row['id'], 'int');
                 $db->query($query, $params);
-                $next_bid = $db->result('bid');
+                $next_bid = $db->result();
                 // set new highest bid
                 $params = array();
-                $extra = ", current_bid = :next_bid, current_bid_id = :current_bid_id";
-                $params[] = array(':next_bid', $next_bid, 'float');
-                $params[] = array(':current_bid_id', $row['id'], 'int');
+                $extra = ", current_bid = :current_bid, current_bid_id = :current_bid_id";
+                $params[] = array(':current_bid', $next_bid['bid'], 'float');
+                $params[] = array(':current_bid_id', $next_bid['bid_id'], 'int');
             }
             $query = "UPDATE " . $DBPrefix . "auctions SET num_bids = num_bids - 1" . $extra . " WHERE id = :auc_id";
             $params[] = array(':auc_id', $row['id'], 'int');


### PR DESCRIPTION
When a highest bid was deleted, the auction update incorrectly set the current_bid_id to the id of that auction. Fixed so the current_bid_id is set to the id of the (next) highest bid.