### PR TITLE
Fix $system variable scope

### DIFF
--- a/includes/functions_admin.php
+++ b/includes/functions_admin.php
@@ -112,7 +112,6 @@ if (!defined('AdminFuncCall')) {
             $curl = curl_init();
             curl_setopt($curl, CURLOPT_URL, $url);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($curl, CURLOPT_REFERER, $system->SETTINGS['siteurl']);
             $str = curl_exec($curl);
             curl_close($curl);
             return $str;


### PR DESCRIPTION
$system is not declared global. Fixed by removing reference (since setting referer is unnecessary and setting it to url might unwantedly disclose information).