### PR TITLE
CACHE_PATH added

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -16,7 +16,7 @@ if (!defined('InWeBid')) {
     exit();
 }
 
-$fp = fopen("/cache/lock.txt", "w+");
+$fp = fopen(CACHE_PATH . 'lock.txt', 'w+');
 
 // do an exclusive lock
 if (flock($fp, LOCK_EX | LOCK_NB)) {


### PR DESCRIPTION
Auctions items were not closing due to the forward slash that was at the start there. Adding CACHE_PATH fixes the issue.