### PR TITLE
lock.txt update

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -16,7 +16,7 @@ if (!defined('InWeBid')) {
     exit();
 }
 
-$fp = fopen("/cache/lock.txt", "w+");
+$fp = fopen(CACHE_PATH . 'lock.txt', 'w+');
 
 // do an exclusive lock
 if (flock($fp, LOCK_EX | LOCK_NB)) {


### PR DESCRIPTION
failed to write the text file as /cache/lock.txt. Making it like this fixed this cache/lock.txt fixed the issue. We can also update it one step further to be more modern code as $fp = fopen(CACHE_PATH . 'lock.txt', 'w+');

It works both ways. It's been tested.