### PR TITLE
spl_autoload_register

### DIFF
--- a/includes/packages/PHPMailer/PHPMailerAutoload.php
+++ b/includes/packages/PHPMailer/PHPMailerAutoload.php
@@ -42,7 +42,7 @@ if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
      * Fall back to traditional autoload for old PHP versions
      * @param string $classname The name of the class to load
      */
-    function __autoload($classname)
+    function spl_autoload_register($classname)
     {
         PHPMailerAutoload($classname);
     }


### PR DESCRIPTION
 Error Reported this after final sell was submitted:
__autoload() is deprecated, use spl_autoload_register() instead