### PR TITLE
parse time string

### DIFF
--- a/includes/Date.php
+++ b/includes/Date.php
@@ -83,7 +83,7 @@ class Date
     public function formatDate($raw_date, $format = false, $UTC_input = true)
     {
         if ($UTC_input) {
-            $datetime = new DateTime($raw_date, $this->UTCtimezone);
+            $datetime = new DateTime(strtotime($raw_date), $this->UTCtimezone);
             $datetime->setTimezone($this->timezone);
         } else {
             $datetime = new DateTime($raw_date, $this->timezone);


### PR DESCRIPTION
Got this error on the item.php page:
Fatal error: Uncaught Exception: DateTime::__construct(): Failed to parse time string (1375794060) at position 8 (6): Unexpected character

I was also getting a blank item.php page.

This update fixes that and it will now show the item page.