### PR TITLE
blank item page issue fix

### DIFF
--- a/includes/Date.php
+++ b/includes/Date.php
@@ -83,10 +83,10 @@ class Date
     public function formatDate($raw_date, $format = false, $UTC_input = true)
     {
         if ($UTC_input) {
-            $datetime = new DateTime($raw_date, $this->UTCtimezone);
+            $datetime = new DateTime('now', $this->UTCtimezone);
             $datetime->setTimezone($this->timezone);
         } else {
-            $datetime = new DateTime($raw_date, $this->timezone);
+            $datetime = new DateTime('now', $this->timezone);
         }
         if (!$format) {
             return $datetime->format($this->defaultformat);


### PR DESCRIPTION
Having it as $raw_date was causing a blank item.php and generate a parse time error.